### PR TITLE
feat(three): Added support for forwarded ref with ThreeView. 

### DIFF
--- a/apps/docs/.gitignore
+++ b/apps/docs/.gitignore
@@ -1,2 +1,3 @@
 *-sidebar.js
 api/*
+!api/.gitkeep

--- a/apps/docs/examples/three/UseCannon.md
+++ b/apps/docs/examples/three/UseCannon.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 5
+sidebar_label: Use Cannon
+title: Use Cannon
+---
+
+import Highlight, { defaultProps } from 'prism-react-renderer';
+import { Example } from '../../src/components/Example';
+import thisSource from '!!raw-loader!../../src/scenes/UseCannon';
+import { UseCannon } from '../../src/scenes/UseCannon';
+
+<Example code={thisSource} style={{minHeight: "400px", padding: "1em" }}>
+<UseCannon />
+</Example>

--- a/apps/docs/src/scenes/UseCannon.tsx
+++ b/apps/docs/src/scenes/UseCannon.tsx
@@ -1,0 +1,181 @@
+import {
+    Entity,
+    Facet,
+    useAnimationFrame,
+    useECS,
+    useQuery,
+    useSystem
+} from '@react-ecs/core';
+import { ThreeView } from '@react-ecs/three';
+import {
+    Physics,
+    PublicApi,
+    useBox,
+    useCylinder,
+    usePlane,
+    useSphere
+} from '@react-three/cannon';
+import {
+    Box,
+    Cone,
+    ContactShadows,
+    Icosahedron,
+    OrbitControls,
+    PerspectiveCamera,
+    Plane
+} from '@react-three/drei';
+import { Canvas, useThree } from '@react-three/fiber';
+import { button, useControls } from 'leva';
+import React, { FC, useEffect, useRef } from 'react';
+import { Raycaster, Vector3 } from 'three';
+
+class PhysicsApi extends Facet<PhysicsApi> {
+    api?: PublicApi;
+}
+
+function Ground(props) {
+    const [ref] = usePlane(() => ({
+        rotation: [-Math.PI / 2, 0, 0],
+        ...props,
+    }));
+    return (
+        <Entity>
+            <ThreeView forwardRef={ref}>
+                <Plane args={[100, 100]}>
+                    <meshBasicMaterial color="white" />
+                </Plane>
+            </ThreeView>
+        </Entity>
+    );
+}
+
+function Cube(props) {
+    const [ref, api] = useBox(() => ({
+        mass: 1,
+        position: [0, 5, 0],
+        ...props,
+    }));
+    useControls({
+        'Bounce Cube': button(() => api.applyForce([0, 500, 0], [0, 0, 0])),
+    });
+    return (
+        <Entity>
+            <ThreeView forwardRef={ref}>
+                <Box>
+                    <meshBasicMaterial color={0x00ff00} />
+                </Box>
+            </ThreeView>
+            <PhysicsApi api={api} />
+        </Entity>
+    );
+}
+
+function Ball(props) {
+    const [ref, api] = useSphere(() => ({
+        mass: 1,
+        position: [0, 5, 2],
+        ...props,
+    }));
+    useControls({
+        'Bounce Ball': button(() => api.applyForce([0, 500, 0], [0, 0, 0])),
+    });
+    return (
+        <Entity>
+            <ThreeView forwardRef={ref}>
+                <Icosahedron args={[1, 2]}>
+                    <meshBasicMaterial color={0xff0000} />
+                </Icosahedron>
+            </ThreeView>
+            <PhysicsApi api={api} />
+        </Entity>
+    );
+}
+
+function Diamond(props) {
+    const [ref, api] = useCylinder(() => ({
+        mass: 1,
+        args: [0.1, 1, 1, 8],
+        rotation: [Math.PI, 0, 0],
+        position: [0, 5, 4],
+        ...props,
+    }));
+    useControls({
+        'Bounce Diamond': button(() => api.applyForce([0, 500, 0], [0, 0, 0])),
+    });
+
+    return (
+        <Entity>
+            <ThreeView forwardRef={ref}>
+                <Cone>
+                    <meshBasicMaterial color={0x0000ff} />
+                </Cone>
+            </ThreeView>
+            <PhysicsApi api={api} />
+        </Entity>
+    );
+}
+
+export const MouseSystem = () => {
+    const query = useQuery((e) => e.hasAll(PhysicsApi, ThreeView));
+    const { gl, scene, camera, mouse } = useThree();
+    const intersectPoint = new Vector3();
+    const raycaster = useRef(new Raycaster());
+    const isMouseDown = useRef(false);
+
+    useEffect(() => {
+        const onMouseDown = (/*event: MouseEvent*/) => {
+            isMouseDown.current = true;
+        };
+        const onMouseUp = (/*event: MouseEvent*/) => {
+            isMouseDown.current = false;
+        };
+        gl.domElement.addEventListener('pointerdown', onMouseDown);
+        gl.domElement.addEventListener('pointerup', onMouseUp);
+        return () => {
+            // unsubscribe event
+            gl.domElement.removeEventListener('pointerdown', onMouseDown);
+            gl.domElement.removeEventListener('pointerup', onMouseUp);
+        };
+    }, [gl.domElement]);
+
+    return useSystem((dt) => {
+        raycaster.current.setFromCamera(mouse, camera);
+        query.loop([ThreeView, PhysicsApi], (e, [view, physics]) => {
+            const intersects = raycaster.current.intersectObject(view.object3d);
+            if (intersects.length !== 0) {
+                physics.api.applyForce([0, 20, 0], [0, 0, 0]);
+            }
+        });
+    });
+};
+
+export const UseCannon: FC = () => {
+    const ECS = useECS();
+    useAnimationFrame(ECS.update);
+
+    return (
+        <Canvas>
+            <OrbitControls />
+            <PerspectiveCamera makeDefault position={[10, 4, 10]}>
+                <ambientLight intensity={0.2} />
+                <directionalLight position={[1, 1, 1]} />
+            </PerspectiveCamera>
+            <ECS.Provider>
+                <Physics>
+                    <Cube />
+                    <Ball />
+                    <Diamond />
+                    <ContactShadows
+                        position={[0, 0, 0]}
+                        width={20}
+                        height={20}
+                        far={20}
+                        rotation={[Math.PI / 2, 0, 0]}
+                    />
+                    <Ground position={[0, -0.01, 0]} />
+                </Physics>
+                <MouseSystem />
+            </ECS.Provider>
+        </Canvas>
+    );
+};

--- a/libs/three/.babelrc
+++ b/libs/three/.babelrc
@@ -1,12 +1,12 @@
 {
-  "presets": [
-    [
-      "@nrwl/react/babel",
-      {
-        "runtime": "automatic",
-        "useBuiltIns": "usage"
-      }
-    ]
-  ],
-  "plugins": []
+    "presets": [
+        [
+            "@nrwl/react/babel",
+            {
+                "runtime": "automatic",
+                "useBuiltIns": "usage"
+            }
+        ]
+    ],
+    "plugins": []
 }

--- a/libs/three/jest.config.js
+++ b/libs/three/jest.config.js
@@ -6,4 +6,5 @@ module.exports = {
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
   coverageDirectory: '../../coverage/libs/three',
+  setupFilesAfterEnv: ['./jest.stubs.js'],
 };

--- a/libs/three/jest.stubs.js
+++ b/libs/three/jest.stubs.js
@@ -1,0 +1,2 @@
+global.URL.createObjectURL = jest.fn();
+global.ResizeObserver = require('resize-observer-polyfill')

--- a/libs/three/src/components/ThreeView/ThreeView.spec.tsx
+++ b/libs/three/src/components/ThreeView/ThreeView.spec.tsx
@@ -2,14 +2,29 @@ import { Box } from "@react-three/drei";
 import { Canvas } from "@react-three/fiber";
 import { render } from "@testing-library/react";
 import React from "react";
+import { Object3D } from "three";
 
 import { ThreeView } from "./index";
 
+
+
 describe('ThreeView', () => {
+
     it('should render successfully', () => {
         const { baseElement } = render(
             <Canvas>
                 <ThreeView>
+                    <Box />
+                </ThreeView>
+            </Canvas>);
+        expect(baseElement).toBeTruthy();
+    });
+
+    it('should render successfully with forwardRef', () => {
+        const ref = React.createRef<Object3D>();
+        const { baseElement } = render(
+            <Canvas>
+                <ThreeView forwardRef={ref}>
                     <Box />
                 </ThreeView>
             </Canvas>);

--- a/libs/three/src/components/ThreeView/index.tsx
+++ b/libs/three/src/components/ThreeView/index.tsx
@@ -7,12 +7,20 @@ import React, {
     ReactElement,
     RefObject
 } from 'react';
+import mergeRefs from 'react-merge-refs';
 import { Object3D } from 'three';
 
 export interface ThreeViewProps {
     children: ReactElement;
+    forwardRef?: RefObject<Object3D>;
 }
 
+/**
+ * A modification of https://github.com/dustinlacewell/react-ecs/blob/master/libs/three/src/components/ThreeView/index.tsx
+ * Adds forwarding the ref for the contained object
+ * @see https://github.com/dustinlacewell/react-ecs/issues/6
+ * Solution contributed by @Honga1
+ */
 export class ThreeView extends Component<ThreeViewProps> {
     static contextType = EntityContext;
     context!: ContextType<typeof EntityContext>;
@@ -37,9 +45,17 @@ export class ThreeView extends Component<ThreeViewProps> {
             throw new Error('<ThreeView /> must have a single child.');
         }
 
-        return <>{React.cloneElement(this.props.children, { ref: this.ref })}</>;
+        return (
+            <>
+                {React.cloneElement(this.props.children, {
+                    ref: this.props.forwardRef
+                        ? mergeRefs([this.ref, this.props.forwardRef])
+                        : this.ref,
+                })}
+            </>
+        );
     }
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-(ThreeView as any).__componentClassId__ = 100
+(ThreeView as any).__componentClassId__ = 100;

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
         "@fortawesome/free-solid-svg-icons": "^5.15.3",
         "@fortawesome/react-fontawesome": "^0.1.14",
         "@mdx-js/react": "^1.6.21",
+        "@react-three/cannon": "^3.1.2",
         "@react-three/drei": "^4.1.8",
         "@react-three/fiber": "^6.0.14",
         "clsx": "^1.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3261,6 +3261,14 @@
     "@react-spring/shared" "~9.1.1"
     "@react-spring/types" "~9.1.1"
 
+"@react-three/cannon@^3.1.2":
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/@react-three/cannon/-/cannon-3.1.2.tgz#8d0cfc364abe24f04548377bbfca401fe79a6b5d"
+  integrity sha512-yZuZv4B90klJeW3GT1Gyqom62s7kcDtwODQjf0cWfThDytzSZQgkd3AY7pSg9l19K/YE0NaPwYSzrGadT4ya8A==
+  dependencies:
+    cannon-es "^0.18.0"
+    cannon-es-debugger "^0.1.4"
+
 "@react-three/drei@^4.1.8":
   version "4.1.8"
   resolved "https://registry.yarnpkg.com/@react-three/drei/-/drei-4.1.8.tgz#66b05dc656f1c2077e7443918cfc3ac41e27931b"
@@ -6182,6 +6190,16 @@ caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001030, caniuse-lite@^1.0.30001032, can
   version "1.0.30001214"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001214.tgz#70f153c78223515c6d37a9fde6cd69250da9d872"
   integrity sha512-O2/SCpuaU3eASWVaesQirZv1MSjUNOvmugaD8zNSJqw6Vv5SGwoOpA9LJs3pNPfM745nxqPvfZY3MQKY4AKHYg==
+
+cannon-es-debugger@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/cannon-es-debugger/-/cannon-es-debugger-0.1.4.tgz#22c79ae14c52de44465690988ff647c51c79c62b"
+  integrity sha512-RefSPWX6gDMQsx3UWoQpkGW3R03Wwn8p1JteexQUYxDC5DnOS3U3iKhns2vVpFp6Q3AKiSSmRf7NIXnGN8L0RA==
+
+cannon-es@^0.18.0:
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/cannon-es/-/cannon-es-0.18.0.tgz#ae831ff9df2352d5faabb269c11ea0f10bc35c7e"
+  integrity sha512-GiQ1bd0etZsMVSnUhNc+p+FEh0R/cULpp8uRSAhEK4Kax+y/31Au03m6h1h1xdDivAMnFg8YDwevHgzLynOHlw==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Example implementation added to docs.

The example uses `@react-three/cannon` which uses hooks to set up physics, you can then add the `api` that is created to communicate with the Physics worker to a facet and that can be used within a ECS system.

```typescript
class PhysicsApi extends Facet<PhysicsApi> {
    api?: PublicApi;
}
```

`@react-three/cannon` uses a ref and return an api to update the body in the worker.  `ThreeView` now support a `forwardRef` prop which will be merged with the innerRef of the `ThreeView`.  This means you must alway add the ref to the `ThreeView` component and never the child Component.

```typescript
function Cube(props) {
    const [ref, api] = useBox(() => ({  mass: 1, position: [0, 5, 0], ...props }));
    return (
        <Entity>
            <ThreeView forwardRef={ref}>
                <Box>
                    <meshBasicMaterial color={0x00ff00} />
                </Box>
            </ThreeView>
            <PhysicsApi api={api} />
        </Entity>
    );
}
```

Here you will see the relevant code for how the api is pulled from the facet to be used.

```
    return useSystem((dt) => {
        raycaster.current.setFromCamera(mouse, camera);
        query.loop([ThreeView, PhysicsApi], (e, [view, physics]) => {
            const intersects = raycaster.current.intersectObject(view.object3d);
            if (intersects.length !== 0) {
                physics.api.applyForce([0, 20, 0], [0, 0, 0]);
            }
        });
    });
```

closes #6 